### PR TITLE
Instant portals

### DIFF
--- a/desk/lib/plow.hoon
+++ b/desk/lib/plow.hoon
@@ -425,6 +425,8 @@
           (husk-spec +.grit)
             %del-shade
           (frond 'shadeId' (numb +.grit))
+            %move-shade
+          (pairs ~['shadeId'^(numb shade-id.grit) pos+(svec2 pos.grit)])
             %cycle-shade
           (pairs ~['shadeId'^(numb shade-id.grit) amount+(numb amt.grit)])
             %set-shade-var
@@ -943,6 +945,7 @@
           del-form+(ot ~['formId'^pa])
           add-husk+husk-spec
           del-shade+(ot ~['shadeId'^ni])
+          move-shade+(ot ~['shadeId'^ni pos+svec2])
           cycle-shade+(ot ~['shadeId'^ni amount+ni])
           set-shade-var+(ot ~['shadeId'^ni variation+ni])
           set-shade-effect+(ot ~['shadeId'^ni trigger+(cork so trigger) effect+maybe-possible-effect])

--- a/desk/lib/turf.hoon
+++ b/desk/lib/turf.hoon
@@ -362,12 +362,15 @@
 ++  get-things
   |=  [=turf pos=svec2]
   ^-  (list thing)
-  %+  murn  (get-shades turf pos)
-  |=  =shade
-  =/  form  (get-form turf form-id.shade)
+  =/  space  (get-space spaces.plot.turf pos)
+  =/  husks=(list husk)
+    (turn (get-shades turf pos) |=(=shade +.shade))
+  =.  husks  ?~(tile.space husks [u.tile.space husks])
+  %+  murn  husks
+  |=  =husk
+  =/  form  (get-form turf form-id.husk)
   ?~  form  ~
-  `[+.shade u.form]
-  
+  `[husk u.form]
 ::
 ++  get-collidable
   |=  [=turf pos=svec2]

--- a/desk/lib/turf.hoon
+++ b/desk/lib/turf.hoon
@@ -531,6 +531,20 @@
   |=  =space
   space(shades (skip shades.space |=(sid=@ =(sid id))))
 ::
+++  move-shade
+  |=  [=turf id=shade-id pos=svec2]
+  ^-  ^turf
+  =/  shade  (~(gut by cave.plot.turf) id ~)
+  ?~  shade  turf
+  =/  old-pos  pos.shade
+  =.  cave.plot.turf
+    %+  ~(put by cave.plot.turf)  id
+    shade(pos pos)
+  =.  turf  (del-shade-from-space turf id old-pos)
+  %^  jab-by-spaces  turf  pos
+  |=  =space  ^-  _space
+  space(shades [id shades.space])
+::
 ++  cycle-shade
   |=  [=turf id=shade-id amt=@ud]
   ^-  ^turf

--- a/desk/sur/pond.hoon
+++ b/desk/sur/pond.hoon
@@ -25,6 +25,7 @@
       del-form-grit
       add-husk-grit
       del-shade-grit
+      move-shade-grit
       cycle-shade-grit
       set-shade-var-grit
       set-shade-effect-grit
@@ -56,6 +57,7 @@
 +$  del-form-grit  [%del-form =form-id]
 +$  add-husk-grit  [%add-husk husk-spec]
 +$  del-shade-grit  [%del-shade =shade-id]
++$  move-shade-grit  [%move-shade =shade-id pos=svec2]
 +$  cycle-shade-grit  [%cycle-shade =shade-id amt=@ud]
 +$  set-shade-var-grit  [%set-shade-var =shade-id variation=@ud]
 +$  set-shade-effect-grit
@@ -186,6 +188,7 @@
     %del-form  (del-form turf form-id.grit)
     %add-husk  (add-husk turf +.grit)
     %del-shade  (del-shade turf +.grit)
+    %move-shade  (move-shade turf +.grit)
     %cycle-shade  (cycle-shade turf +.grit)
     %set-shade-var  (set-shade-var turf +.grit)
     %set-shade-effect  (set-shade-effect turf +.grit)

--- a/src/components/Modals.jsx
+++ b/src/components/Modals.jsx
@@ -110,7 +110,7 @@ export default function Modals() {
       </Show>
       <Show when={state.text}>
         <Modal class="border-yellow-950 border-4 rounded-md bg-yellow-700" onClose={() => state.displayText(null)}>
-          <p class="text-xl mb-4 text-center">
+          <p class="text-xl mb-4 text-center whitespace-pre">
             {state.text}
           </p>
           <div class="mt-4 text-center">

--- a/src/components/Modals.jsx
+++ b/src/components/Modals.jsx
@@ -23,30 +23,42 @@ export default function Modals() {
 
   return (
     <>
-      <Show when={state.v?.portOffer} keyed>
-        <Modal class="bg-teal-700 text-slate-100 w-96">
-          <p class="text-xl mb-4 text-center">
-            {state.v.portOffer.of ?
-              "You've activated a portal!"
-            :
-              "You've been summoned!"
-            }
-          </p>
-          <p class="mb-2">
-            Would you like to travel to:
-          </p>
-          <p class="text-center text-lg">
-            <span class="font-bold">{stripPathPrefix(state.v.portOffer.for)}</span>?
-          </p>
-          <div class="flex w-full justify-center mt-4 space-x-4">
-            <button use:autofocus class="bg-teal-800 rounded-lg px-4 py-2" onClick={state.mist.acceptPortOffer.bind(state.mist)}>
-              Yes
-            </button>
-            <button class="bg-teal-800 rounded-lg px-4 py-2" onClick={state.mist.rejectPortOffer.bind(state.mist)}>
-              No
-            </button>
-          </div>
-        </Modal>
+      <Show when={state.portOffer || state.v?.portOffer} keyed>
+        {(portOffer) => {
+          function accept() {
+            state.mist.acceptPortOffer(portOffer);
+            state.setPortOffer(null);
+          }
+          function reject() {
+            state.mist.rejectPortOffer(portOffer);
+            state.setPortOffer(null);
+          }
+
+          return (
+          <Modal class="bg-teal-700 text-slate-100 w-96">
+            <p class="text-xl mb-4 text-center">
+              {portOffer.of ?
+                "You've activated a portal!"
+              :
+                "You've been summoned!"
+              }
+            </p>
+            <p class="mb-2">
+              Would you like to travel to:
+            </p>
+            <p class="text-center text-lg">
+              <span class="font-bold">{stripPathPrefix(portOffer.for)}</span>?
+            </p>
+            <div class="flex w-full justify-center mt-4 space-x-4">
+              <button use:autofocus class="bg-teal-800 rounded-lg px-4 py-2" onClick={accept}>
+                Yes
+              </button>
+              <button class="bg-teal-800 rounded-lg px-4 py-2" onClick={reject}>
+                No
+              </button>
+            </div>
+          </Modal>);
+        }}
       </Show>
       <Show when={state.m && (!state.e || !state.player)} keyed>
         <Modal class="bg-teal-700 text-slate-100 w-96">

--- a/src/components/ShadeEditor.jsx
+++ b/src/components/ShadeEditor.jsx
@@ -138,7 +138,7 @@ function ArgInput(props) {
             <SmallButton onClick={[props.setArg, null]} >x</SmallButton>
           </Match>
           <Match when={props.type === 'read'}>
-            <input
+            <textarea
               class="rounded-input max-w-[160px]"
               use:input
               use:bind={[

--- a/src/lib/mist.js
+++ b/src/lib/mist.js
@@ -14,7 +14,12 @@ export class Mist { // we use a class so we can put it inside a store without ge
     const apiSendWave = (...args) => {
       api.sendMistWave(id, ...args);
     };
-    this._ = getPool(washMist, null, apiSendWave, filters(this), options);
+    options = {
+      ...options,
+      // preFilters,
+      filters: filters(this),
+    };
+    this._ = getPool(washMist, null, apiSendWave, options);
     this.$ = this._.$;
     const [local, { mutate, refetch }] = createResource(api.getLocal);
     this._local = local;
@@ -87,15 +92,15 @@ export class Mist { // we use a class so we can put it inside a store without ge
     });
   }
 
-  acceptPortOffer() {
-    if (this.vapor?.portOffer) {
-      this.sendWave('accept-port-offer', this.vapor.portOffer.for);
+  acceptPortOffer(portOffer) {
+    if (portOffer) {
+      this.sendWave('accept-port-offer', portOffer.for);
     }
   }
 
-  rejectPortOffer() {
-    if (this.vapor?.portOffer) {
-      this.sendWave('reject-port-offer', this.vapor.portOffer.for);
+  rejectPortOffer(portOffer) {
+    if (portOffer) {
+      this.sendWave('reject-port-offer', portOffer.for);
     }
   }
 
@@ -180,29 +185,32 @@ export function _washMist(grit) {
   });
 }
 
-// returns an object of functions which
-// return false if goal is rejected
-// otherwise, returns a pair of [goal, grit]
-// or, more commonly, a single goal/grit
+// These simulate the filters on the ship
+// returns either
+// Array<grit>
+//   or
+// {
+//   roars: Array<roar>, // side-effects
+//   grits: Array<grit>, // what grits does this translate to?
+//   goals: Array<goal>, // what sub-goals does this trigger?
+// }
 function filters(mistPool) {
   return {
     'add-thing-from-closet': (mist, goal) => {
       const formId = goal.arg;
       const form = mistPool.closet?.[formId];
-      const husk = {
-        ...generateHusk(formId),
-        form,
-      }
       if (!form) {
-        return false;
+        return [];
       } else {
+        const husk = {
+          ...generateHusk(formId),
+          form,
+        };
         return [
-          goal,
-          {
-            type: 'add-thing',
-            arg: husk,
-          }
-        ]
+        {
+          type: 'add-thing',
+          arg: husk,
+        }];
       }
     }
   };

--- a/src/lib/pond.js
+++ b/src/lib/pond.js
@@ -4,7 +4,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import * as api from 'lib/api.js';
 import {
   clampToTurf, isInTurf, getCollision, getEffectsByHusk,
-  generateHusk, jabBySpaces, delShade, delPortal,
+  generateHusk, jabBySpaces, delShade, delShadeFromSpace, delPortal,
   getThingsAtPos, getEffectsByThing,
 } from 'lib/turf';
 import { vec2, vecToStr, jClone, turfIdToPath } from 'lib/utils';
@@ -183,6 +183,16 @@ const pondGrits = {
   },
   'del-shade': (turf, arg) => {
     delShade(turf, arg.shadeId);
+  },
+  'move-shade': (turf, arg) => {
+    const { shadeId, pos } = arg;
+    const shade = turf.cave[shadeId];
+    if (shade) {
+      const oldPos = shade.pos;
+      shade.pos = pos;
+      delShadeFromSpace(turf, shadeId, oldPos);
+      jabBySpaces(turf, pos, space => space.shades.unshift(shadeId));
+    }
   },
   'cycle-shade': (turf, arg) => {
     const { shadeId, amount } = arg;

--- a/src/lib/turf.js
+++ b/src/lib/turf.js
@@ -80,6 +80,13 @@ export function getShadesAtPos(turf, pos) {
   return shades.map(sid => getShadeWithForm(turf, sid)).filter(shade => shade);
 }
 
+export function getThingsAtPos(turf, pos) {
+  const tile = getTileWithForm(turf, pos);
+  const shades = getShadesAtPos(turf, pos);
+  if (tile) return [tile, ...shades];
+  return shades;
+}
+
 export function getShadesAtPosByType(turf, pos, type) {
   return getShadesAtPos(turf, pos).filter(shade => shade.form.type === type);
 }
@@ -115,16 +122,23 @@ export function getCollision(turf, pos) {
 
 export function getEffectsByHusk(turf, shade) {
   const form = turf.skye[shade.formId];
-  if (!form) return {
-    fullFx: shade.effects,
-    huskFx: shade.effects,
+  return getEffectsByThing({
+    ...shade,
+    form,
+  });
+}
+
+export function getEffectsByThing(thing) {
+  if (!thing.form) return {
+    fullFx: thing.effects,
+    huskFx: thing.effects,
     formFx: {},
   };
-  const formFx = Object.assign({}, form.seeds, form.effects);
-  const fullFx = Object.assign({}, formFx, shade.effects);
+  const formFx = Object.assign({}, thing.form.seeds, thing.form.effects);
+  const fullFx = Object.assign({}, formFx, thing.effects);
   return {
     fullFx,
-    huskFx: shade.effects,
+    huskFx: thing.effects,
     formFx,
   };
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -166,6 +166,10 @@ export function stripPathPrefix(path) {
   return path.replace(/\/[^/]+\//, '');
 }
 
+export function turfIdToPath(turfId) {
+  return '/pond/' + turfId.ship + (turfId.path !== '/' ? turfId.path : '');
+}
+
 export function truncateString(str, maxLength) {
   if (str.length > maxLength) {
     const truncated = str.slice(0, maxLength - 3);

--- a/src/phaser/game.js
+++ b/src/phaser/game.js
@@ -330,16 +330,25 @@ export function startPhaser(_owner, _container) {
         gritController.abort();
         gritController = new AbortController();
 
-        addGritListener('pond-ping-player', (e) => {
+        addGritListener('pond-grit-ping-player', (e) => {
           if (e.grit.arg.ship === our) {
             if (!this.sound.locked && state.soundOn) ping.play();
             state.notify(e.grit.arg.by + ' has pinged you!');
           }
         });
-        const moveQueuer = (e) => { if (players[e.grit.arg.ship]) players[e.grit.arg.ship].actionQueue.push(e.grit); };
-        addGritListener('pond-move', moveQueuer);
-        addGritListener('pond-face', moveQueuer);
-        addGritListener('pond-chat', (e) => {
+        const themMoveQueuer = (e) => {
+          const ship = e.grit.arg.ship;
+          if (ship !== our && players[ship]) players[ship].actionQueue.push(e.grit);
+        };
+        addGritListener('pond-grit-move', themMoveQueuer);
+        addGritListener('pond-grit-face', themMoveQueuer);
+        const usMoveQueuer = (e) => {
+          const ship = e.fakeGrit.arg.ship;
+          if (ship === our && players[ship]) players[ship].actionQueue.push(e.fakeGrit);
+        };
+        addGritListener('pond-fakeGrit-move', usMoveQueuer);
+        addGritListener('pond-fakeGrit-face', usMoveQueuer);
+        addGritListener('pond-grit-chat', (e) => {
           if (state.soundOn) {
             var msg = new SpeechSynthesisUtterance();
             msg.text = e.grit.arg.text;

--- a/src/phaser/game.js
+++ b/src/phaser/game.js
@@ -211,7 +211,7 @@ function createShade(shade, id, turf) {
 }
 
 function setGameSize() {
-  console.log('resized')
+  // console.log('resized')
   const el = game.scale.isFullscreen ? game.canvas.parentElement : container;
   const width = ~~(window.devicePixelRatio * el.clientWidth);
   const height = ~~(window.devicePixelRatio * el.clientHeight);
@@ -565,7 +565,7 @@ export function startPhaser(_owner, _container) {
         } else {
           if (shadeObject.texture.key !== (sprite = spriteName(shadeData.formId, shadeData.variation))) {
             shadeObject.setTexture(sprite);
-            console.log('updated shade at', shadeData.pos)
+            // console.log('updated shade at', shadeData.pos)
           }
         }
       });

--- a/src/phaser/game.js
+++ b/src/phaser/game.js
@@ -86,6 +86,7 @@ async function loadImageUnsafe(id, url, config = {}) {
           game.textures.removeKey(id);
         }
       }
+      if (game.textures.exists(id)) return;
       const texture = game.textures.create(id, images, images[0].width, images[0].height);
       if (!texture) reject('could not create texture for: ' + url[0]);
       images.forEach((img, i) => {

--- a/src/phaser/player.js
+++ b/src/phaser/player.js
@@ -20,8 +20,10 @@ export class Player extends Phaser.GameObjects.Container {
     this.patp = patp;
     this.isUs = patp === our;
     if (this.isUs) {
-      this.cursors = scene.input.keyboard.createCursorKeys();
-      this.keys = scene.input.keyboard.addKeys({ w: 'W', a: 'A', s: 'S', d: 'D' });
+      this.keys = {
+        ...scene.input.keyboard.createCursorKeys(),
+        ...scene.input.keyboard.addKeys({ w: 'W', a: 'A', s: 'S', d: 'D' }),
+      };
       scene.cameras.main.startFollow(this);
     }
     this.loadPlayerSprites = load;
@@ -65,7 +67,7 @@ export class Player extends Phaser.GameObjects.Container {
         if (pos) {
           // make sure to use x and y so solid knows to track them
           // we aren't tracking player, so that's no help
-          console.log('new player pos', pos.x, pos.y)
+          // console.log('new player pos', pos.x, pos.y)
           this.tilePos = vec2(pos.x, pos.y)
         }
       });
@@ -143,7 +145,7 @@ export class Player extends Phaser.GameObjects.Container {
       spriteDirs.forEach((key, i) => {
         if (!key) return;
         let frameKeys = Object.keys(game.textures.get(key).frames);
-        const frames = frameKeys.map((frame) => { return { key, frame }});
+        const frames = frameKeys.map((frame) => { return { key, frame }}).filter(({ frame }) => frame !== '__BASE');
         sprite.anims.create({
           key: dirs[i],
           frames,
@@ -215,6 +217,9 @@ export class Player extends Phaser.GameObjects.Container {
   }
 
   preUpdate(time, dt) {
+    if (!game.input.keyboard.enabled && this.keys) {
+      Object.values(this.keys).forEach(k => k.reset());
+    }
     //Action queue retirement here. The objects in the action queue are just grits.
     //The code that fills the actionQueue is the event handlers, window.addEventListener lines in game.js:startPhaser. These trigger only on confirmed events. 
     //So, the point is that this is a little sneaky side-state that only applies to the presentation, to avoid additional bookkeeping requirements the presentation doesn't need.
@@ -255,19 +260,19 @@ export class Player extends Phaser.GameObjects.Container {
       const newTilePos = vec2(this.tilePos);
       let newDir;
       if (this.dPos.equals(targetPos()) && this.actionQueue.length === 0) {
-        if (this.cursors.left.isDown || this.keys.a.isDown) {
+        if (this.keys.left.isDown || this.keys.a.isDown) {
           newDir = dirs.LEFT;
           newTilePos.x--;
         }
-        if (this.cursors.right.isDown || this.keys.d.isDown) {
+        if (this.keys.right.isDown || this.keys.d.isDown) {
           newDir = dirs.RIGHT;
           newTilePos.x++;
         }
-        if (this.cursors.up.isDown || this.keys.w.isDown) {
+        if (this.keys.up.isDown || this.keys.w.isDown) {
           newDir = dirs.UP;
           newTilePos.y--;
         }
-        if (this.cursors.down.isDown || this.keys.s.isDown) {
+        if (this.keys.down.isDown || this.keys.s.isDown) {
           newDir = dirs.DOWN;
           newTilePos.y++;
         }

--- a/src/phaser/preview.js
+++ b/src/phaser/preview.js
@@ -28,18 +28,22 @@ export class Preview extends Phaser.GameObjects.Container {
       this.dispose = dispose;
       createEffect(() => {
         const editor = this.s.editor;
+        const portaling = !!this.s.portalToPlace;
+        const brushing = !!(editor.editing && editor.brush && editor.selectedFormId);
+        const pointing = !!(editor.editing && editor.pointer && editor.movingShadeId);
+        const movingShade = pointing ? this.turf().cave[editor.movingShadeId] : null;
         this.removeAll(true)
-        if (this.turf() && ((editor.editing && editor.brush && editor.selectedFormId) || this.s.portalToPlace)) {
+        if (this.turf() && (portaling || brushing || pointing)) {
           const shadeDef = {
-            formId: this.s.portalToPlace ? '/portal' : editor.selectedFormId,
-            variation: 0,
+            formId: portaling ? '/portal' : (brushing ? editor.selectedFormId : movingShade.formId),
+            variation: pointing ? (movingShade?.variation || 0) : 0,
             pos: vec2(),
-          }
+          };
+          if (!shadeDef.formId) return;
           this.shade = new Shade(this.scene, shadeDef, this.turf(), false);
-          if (this.shade) {
-            this.shade.setAlpha(0.8);
-            this.add([this.shade]);
-          }
+          if (!this.shade) return;
+          this.shade.setAlpha(0.8);
+          this.add([this.shade]);
         } else {
           this.shade = null;
         }

--- a/src/phaser/shade.js
+++ b/src/phaser/shade.js
@@ -18,4 +18,9 @@ export class Shade extends Phaser.GameObjects.Image {
       }
     }
   }
+
+  setPosition(...args) {
+    super.setPosition(...args);
+    this.setDepth(this.y/tileFactor);
+  }
 }

--- a/src/stores/state.jsx
+++ b/src/stores/state.jsx
@@ -20,6 +20,7 @@ function initEditorState() {
     selectedShadeId: null,
     selectedTool: null,
     portalToPlace: null,
+    movingShadeId: null,
   };
 }
 
@@ -52,6 +53,9 @@ export function getState() {
         ERASER: 'eraser',
         CYCLER: 'cycler',
         RESIZER: 'resizer',
+      },
+      get pointer() {
+        return this.selectedTool === null;
       },
       get brush() {
         return this.selectedTool === this.tools.BRUSH;
@@ -286,6 +290,12 @@ export function getState() {
         shadeId: Number.parseInt(shadeId),
       });
     },
+    moveShade(shadeId, pos) {
+      this.sendPondWave('move-shade', {
+        shadeId: Number.parseInt(shadeId),
+        pos: vec2(pos),
+      });
+    },
     cycleShade(shadeId, amount = 1) {
       this.sendPondWave('cycle-shade', {
         shadeId: Number.parseInt(shadeId),
@@ -413,6 +423,9 @@ export function getState() {
     },
     startPlacingPortal(portalId) {
       $state('editor', 'portalToPlace', portalId);
+    },
+    setMovingShadeId(shadeId) {
+      $state('editor', 'movingShadeId', shadeId);
     },
     toggleSound() {
       $state('soundOn', (muted) => !muted);

--- a/src/stores/state.jsx
+++ b/src/stores/state.jsx
@@ -82,6 +82,7 @@ export function getState() {
     notifications: [],
     text: null,
     soundOn: localStorage.getItem(lsKeys.SOUND_ON) !== 'false',
+    portOffer: null,
     get current() {
       const parent = this;
       const current = {
@@ -224,6 +225,9 @@ export function getState() {
       if (this.mist) {
         return this.mist.sendWave(type, arg, id);
       }
+    },
+    setPortOffer(portOffer) {
+      $state('portOffer', portOffer);
     },
     sendChat(message) {
       this.sendPondWave('send-chat', {
@@ -446,6 +450,19 @@ export function getState() {
 
   createEffect(() => {
     localStorage.setItem(lsKeys.SOUND_ON, _state.soundOn);
+  });
+
+  window.addEventListener('pond-roar-port-offer', ({ roar, turfId }) => {
+    const { ship, from, for: forId, at } = roar.arg;
+    if (ship !== our) return;
+    setTimeout(() => {
+      _state.setPortOffer({
+        for: forId,
+        of: turfId,
+        from,
+        at,
+      });
+    }, 200);
   });
 
   return _state;


### PR DESCRIPTION
- instant portal modals through the magic of actually doing filters better on the frontend
  - changed the pond grit events so we can listen for `pond-grit`, `pond-fake-grit` (ui generated and unconfirmed), or `pond-roar` (a side-effect we expect the backend to generate, used to predict when we'll get a port-offer so we can display the modal
  - also enabled instant tunnel activation
  - and instant portal placement
- bug fixes including recent animations issue
- enable click+drag to move items